### PR TITLE
ci: add paths-ignore conditions to skip jobs for documentation changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,31 +5,33 @@ on:
     branches:
       - master
       - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '*.png'
-      - '*.jpg'
-      - '*.jpeg'
-      - '*.gif'
-      - '*.svg'
-      - 'renovate.json'
-      - '.travis.yml'
+    paths:
+      - 'libs/**'
+      - '__tests__/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'vite.config.ts'
+      - 'eslint.config.js'
+      - '.eslintrc.yml'
+      - '.eslintignore'
+      - '.github/workflows/**'
+      - '.husky/**'
+      - '.lintstagedrc.json'
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'LICENSE'
-      - '.gitignore'
-      - '*.png'
-      - '*.jpg'
-      - '*.jpeg'
-      - '*.gif'
-      - '*.svg'
-      - 'renovate.json'
-      - '.travis.yml'
+    paths:
+      - 'libs/**'
+      - '__tests__/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'vite.config.ts'
+      - 'eslint.config.js'
+      - '.eslintrc.yml'
+      - '.eslintignore'
+      - '.github/workflows/**'
+      - '.husky/**'
+      - '.lintstagedrc.json'
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,31 @@ on:
     branches:
       - master
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '*.png'
+      - '*.jpg'
+      - '*.jpeg'
+      - '*.gif'
+      - '*.svg'
+      - 'renovate.json'
+      - '.travis.yml'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '*.png'
+      - '*.jpg'
+      - '*.jpeg'
+      - '*.gif'
+      - '*.svg'
+      - 'renovate.json'
+      - '.travis.yml'
 
 jobs:
   lint:


### PR DESCRIPTION
ドキュメントや画像ファイルのみの変更時にCIジョブをスキップするように設定:
- Markdownファイル (**.md)
- docsディレクトリ (docs/**)
- LICENSE, .gitignore
- 画像ファイル (*.png, *.jpg, *.jpeg, *.gif, *.svg)
- renovate.json, .travis.yml

これにより、README.mdなどの更新時に不要なlint/test/build/typecheckジョブが実行されなくなります。